### PR TITLE
Log with second-level granularity in csv and make sure each entry gets its own line

### DIFF
--- a/omnikcsv.c
+++ b/omnikcsv.c
@@ -54,9 +54,9 @@ void omnikcsv(void) {
 	}
 
 	pFile = fopen(filename, "a");
-	fprintf(pFile, "%s,%s,%.0f,%.1f,%.1f,%.1f,%.1f,%.1f,%.2f,%.2f,%.1f,%.0f,", 
+	fprintf(pFile, "%s,%s,%.0f,%.1f,%.1f,%.1f,%.1f,%.1f,%.2f,%.2f,%.1f,%.0f\n", 
 		getdatetime(date, 0),
-		getdatetime(now, 1),
+		getdatetime(now, 3),
 		stats.PowerToday,
 		stats.PVPower[0],
 		stats.temperature,

--- a/omnikfunctions.c
+++ b/omnikfunctions.c
@@ -59,7 +59,7 @@ void *get_in_addr(struct sockaddr *sa)
 **	function yyyymmdd(int datetime);
 **
 **	Returns either the date (yyyymmdd) or the time(hh:mm)
-**	depending on datetime (0=date, 1=time)
+**	depending on datetime (0=date, 1=time, 2=year, 3=time+seconds)
 **
 */
 
@@ -79,6 +79,9 @@ char *getdatetime(char *now, int datetime) {
 		break;
 		case 2:
 			strftime(now, 10, "%Y", timeinfo);
+		break;
+		case 3:
+			strftime(now, 10, "%H:%M:%S", timeinfo);
 		break;
 		default:
 			strcpy(now, "no data");


### PR DESCRIPTION
The CSV with logging data is created with minute-level granularity. The inverter (or at least mine) can be queried for data on a per-second level. Log with seconds and allow the user to pick a resolution that he is interested in. 

Not that we can't change the behaviour of the `1` parameter because it's also used in uploading to PVOutput, so a `3` is added. 

Also, the last `,` of the CSV line should be a `\n`. 